### PR TITLE
[compiler] Fix compiler error by static_casting to quint32

### DIFF
--- a/src/engine/memorytable.cpp
+++ b/src/engine/memorytable.cpp
@@ -338,7 +338,7 @@ quint32 MemoryTablePrivate::allocate(quint32 size, TableMetadata *table, bool in
 
     // Align the allocation so that the header is directly accessible
     quint32 allocationSize = static_cast<quint32>(requiredSpace(size));
-    allocationSize = roundUp(allocationSize, sizeof(quint32));
+    allocationSize = roundUp(allocationSize, static_cast<quint32>(sizeof(quint32))));
 
     if (table->freeList) {
         // Try to reuse a freed block


### PR DESCRIPTION
Noticed this build error in x86_64 systems which couldn't convert the value to quint32, but instead converted it to long unsigned int
